### PR TITLE
Quote string values in ranges

### DIFF
--- a/lib/csquery/structured.rb
+++ b/lib/csquery/structured.rb
@@ -71,8 +71,8 @@ module Csquery
 
       def format_range_values(start_val, end_val = nil)
         start_paren = [nil, ''].include?(start_val) ? '{' : '['
-        start_value = [nil, ''].include?(start_val) ? '' : start_val
-        end_value = [nil, ''].include?(end_val) ? '' : end_val
+        start_value = [nil, ''].include?(start_val) ? '' : format_value(start_val)
+        end_value = [nil, ''].include?(end_val) ? '' : format_value(end_val)
         end_paren = [nil, ''].include?(end_val) ? '}' : ']'
 
         "#{start_paren}#{start_value},#{end_value}#{end_paren}"

--- a/spec/csquery/structured_spec.rb
+++ b/spec/csquery/structured_spec.rb
@@ -118,7 +118,13 @@ describe Csquery::Structured do
       expect(Csquery::Structured.range_('[1990,}').query).to eq('(range [1990,})')
 
       expect(Csquery::Structured.range_(['1967-01-31T23:20:50.650Z',
-                                         '1967-01-31T23:59:59.999Z']).query).to eq('(range [1967-01-31T23:20:50.650Z,1967-01-31T23:59:59.999Z])')
+                                         '1967-01-31T23:59:59.999Z']).query).to eq("(range ['1967-01-31T23:20:50.650Z','1967-01-31T23:59:59.999Z'])")
+
+      expect(Csquery::Structured.range_(['1967-01-31T23:20:50.650Z',
+                                         '']).query).to eq("(range ['1967-01-31T23:20:50.650Z',})")
+
+      expect(Csquery::Structured.range_(['90,-180',
+                                         '-89.999,179.999']).query).to eq("(range ['90,-180','-89.999,179.999'])")
 
       expect(Csquery::Structured.range_([1990, 2000], field: 'date', boost: 2).query).to eq('(range field=date boost=2 [1990,2000])')
     end


### PR DESCRIPTION
Without this change I get errors like the following when searching date ranges and latlng ranges:

```
Aws::CloudSearchDomain::Errors::SearchException: Error Count: 4; [1] Syntax error in query: unexpected character 'T' at position (99).; [2] Syntax error in query: unexpected character 'Z' at position (108). [1] Syntax error in query: unexpected token (decimal: -0) at position (93).; [2] Syntax error in query: unexpected token (:) at position (102).
```