### PR TITLE
Add Csquery::Structured::Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
+builder = Csquery::Structured::Builder.new(:and_) do
+  not_('test', field:'genres')
+
+  or_ do
+    term_('star', field:'title', boost:2)
+    term_('star', field:'plot')
+  end
+end
+
+builder.query
+# => "(and (not field=genres 'test') (or (term field=title boost=2 'star') (term field=plot 'star')))"
+```
+
+You can also build a query manually without the DSL:
+
+```ruby
 Csquery::Structured.and_(
     Csquery::Structured.not_('test', field:'genres'),
     Csquery::Structured.or_(
@@ -45,4 +61,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/csquery. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/marcy/csquery. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/csquery.rb
+++ b/lib/csquery.rb
@@ -1,6 +1,8 @@
 require "csquery/version"
 
 require "csquery/structured"
+require "csquery/structured/expression_builder"
+require "csquery/structured/builder"
 
 require "csquery/field_value"
 require "csquery/expression"

--- a/lib/csquery/structured/builder.rb
+++ b/lib/csquery/structured/builder.rb
@@ -1,0 +1,16 @@
+module Csquery
+  class Structured
+    class Builder < ExpressionBuilder
+      attr_reader :root
+
+      def initialize(root, &block)
+        @root = root
+        super(&block)
+      end
+
+      def query
+        Structured.public_send(root, *expressions).query
+      end
+    end
+  end
+end

--- a/lib/csquery/structured/expression_builder.rb
+++ b/lib/csquery/structured/expression_builder.rb
@@ -1,0 +1,27 @@
+module Csquery
+  class Structured
+    class ExpressionBuilder
+      attr_reader :expressions
+
+      def initialize(&block)
+        @expressions = []
+        instance_exec(&block) if block_given?
+      end
+
+      def method_missing(m, *args, &block)
+        args = ExpressionBuilder.new(&block).expressions if block_given?
+        @expressions << Structured.public_send(m, *args)
+      end
+
+      def or_concat_(&block)
+        expressions = ExpressionBuilder.new(&block).expressions
+
+        if expressions.length > 1
+          or_(*expressions)
+        else
+          @expressions.concat(expressions)
+        end
+      end
+    end
+  end
+end

--- a/spec/csquery/structured/builder_spec.rb
+++ b/spec/csquery/structured/builder_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Csquery::Structured::Builder do
+  describe '#query' do
+    let(:builder) do
+      Csquery::Structured::Builder.new(:and_) do
+        not_('test', field:'genres')
+
+        or_ do
+          term_('star', field:'title', boost:2)
+          term_('star', field:'plot')
+        end
+      end
+    end
+
+    specify do
+      expect(builder.query).to eq(
+        <<-CSQUERY.strip.gsub(/\s+/, ' ')
+          (and
+            (not field=genres 'test')
+            (or
+              (term field=title boost=2 'star')
+              (term field=plot 'star')))
+        CSQUERY
+      )
+    end
+  end
+
+  describe '#or_concat_' do
+    context 'with one sub-expression' do
+      let(:builder) do
+        Csquery::Structured::Builder.new(:and_) do
+          not_('test', field:'genres')
+
+          or_concat_ do
+            term_('star', field:'title', boost:2)
+          end
+        end
+      end
+
+      specify do
+        expect(builder.query).to eq(
+          <<-CSQUERY.strip.gsub(/\s+/, ' ')
+            (and
+              (not field=genres 'test')
+              (term field=title boost=2 'star'))
+          CSQUERY
+        )
+      end
+    end
+
+    context 'with multiple sub-expression' do
+      let(:builder) do
+        Csquery::Structured::Builder.new(:and_) do
+          not_('test', field:'genres')
+
+          or_concat_ do
+            term_('star', field:'title', boost:2)
+            term_('star', field:'plot')
+          end
+        end
+      end
+
+      specify do
+        expect(builder.query).to eq(
+          <<-CSQUERY.strip.gsub(/\s+/, ' ')
+            (and
+              (not field=genres 'test')
+              (or
+                (term field=title boost=2 'star')
+                (term field=plot 'star')))
+          CSQUERY
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Usage
 
```ruby
builder = Csquery::Structured::Builder.new(:and_) do
  not_('test', field:'genres')
 
  or_ do
    term_('star', field:'title', boost:2)
    term_('star', field:'plot')
  end
end
 
builder.query
# => "(and (not field=genres 'test') (or (term field=title boost=2 'star') (term field=plot 'star')))"
```